### PR TITLE
allow click 8.*

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ coveragepy-lcov = "coveragepy_lcov.cli:main"
 [tool.poetry.dependencies]
 python = "^3.8"
 coverage = "^5.5"
-click = "^7.1.2"
+click = ">=7.1.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"


### PR DESCRIPTION
Updates the project requirements to allow click 8 to be installed. (`^7.1.2` locked it to `>=7.1.2,<8`)